### PR TITLE
chore: release v1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blaaiz-nodejs-sdk",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blaaiz-nodejs-sdk",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.19.119",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blaaiz-nodejs-sdk",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Official Node.js SDK for Blaaiz RaaS (Remittance as a Service) API",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary

Version bump for the `customers.list()` filter + pagination work merged in #6. Patch bump.

`package.json` and `package-lock.json` only — no source changes.

## Test plan

- [x] `npm install` — lockfile in sync.
- [ ] After merge, tag `v1.1.2` will trigger the `publish` workflow to push to npm.