### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,28 +129,33 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [test, security-audit, build]
     if: github.event_name == 'release' && github.event.action == 'published'
-    
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18.x'
+        node-version: '22.x'
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
-    
+
+    - name: Ensure npm supports OIDC trusted publishing
+      run: npm install -g npm@latest
+
     - name: Install dependencies
       run: npm install
-    
+
     - name: Build package
       run: npm run build
-    
+
     - name: Publish to npm
       env:
         BLAAIZ_API_KEY: ${{ secrets.BLAAIZ_API_KEY }}
         BLAAIZ_WEBHOOK_SECRET: ${{ secrets.BLAAIZ_WEBHOOK_SECRET }}
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: npm publish --access public
 
   publish-dry-run:


### PR DESCRIPTION
## Summary
- Fixes the failed `v1.1.2` release ([run 26411554429](https://github.com/Blaaiz/blaaiz-nodejs-sdk/actions/runs/26411554429)) which was blocked by the package's strict 2FA policy (`auth-and-writes`) rejecting `NPM_TOKEN`.
- Switches the publish job to OIDC trusted publishing — GitHub mints a short-lived OIDC token instead of using a stored npm token, which satisfies the 2FA gate.
- Grants `id-token: write`, bumps Node 18 → 22 (npm 11.5.1+ required), removes `NODE_AUTH_TOKEN`.

The trusted publisher entry on npm (`blaaiz/blaaiz-nodejs-sdk` → `ci.yml`) is already configured.

## Test plan
- [ ] Merge to `main`
- [ ] Delete the existing `v1.1.2` GitHub release (keep the tag) and re-publish it to re-fire the workflow
- [ ] Confirm `blaaiz-nodejs-sdk@1.1.2` appears on the npm registry with a provenance attestation
- [ ] Revoke the `github-automation-publish` npm token and the `NPM_TOKEN` repo secret