### PR TITLE
ci: drop registry-url from setup-node so OIDC handshake runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,10 @@ jobs:
       with:
         node-version: '22.x'
         cache: 'npm'
-        registry-url: 'https://registry.npmjs.org'
+        # Intentionally no registry-url: setup-node would otherwise write
+        # an .npmrc with `_authToken=${NODE_AUTH_TOKEN}` and export a
+        # placeholder NODE_AUTH_TOKEN, which makes npm publish via the
+        # token path and skip the OIDC handshake.
 
     - name: Ensure npm supports OIDC trusted publishing
       run: npm install -g npm@latest


### PR DESCRIPTION
When `registry-url` is set, actions/setup-node writes a temp .npmrc containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and exports NODE_AUTH_TOKEN with the placeholder "XXXXX-XXXXX-XXXXX-XXXXX". npm then expands the placeholder, treats it as a real token, and posts it to the registry instead of attempting the OIDC trusted-publishing handshake. The registry rejects the garbage token as 404, masking what is actually an auth failure.

Without registry-url, setup-node skips both the .npmrc and the placeholder export. npm publishes to its default registry (registry.npmjs.org) and the OIDC flow runs cleanly via the ACTIONS_ID_TOKEN_REQUEST_* env vars that GitHub injects when `id-token: write` is granted.