### PR TITLE
ci: pin npm to 11 via npx so the OIDC handshake runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,9 +146,6 @@ jobs:
         # placeholder NODE_AUTH_TOKEN, which makes npm publish via the
         # token path and skip the OIDC handshake.
 
-    - name: Ensure npm supports OIDC trusted publishing
-      run: npm install -g npm@latest
-
     - name: Install dependencies
       run: npm install
 
@@ -159,7 +156,11 @@ jobs:
       env:
         BLAAIZ_API_KEY: ${{ secrets.BLAAIZ_API_KEY }}
         BLAAIZ_WEBHOOK_SECRET: ${{ secrets.BLAAIZ_WEBHOOK_SECRET }}
-      run: npm publish --access public
+      # Node 22's bundled npm is 10.x, which predates OIDC trusted
+      # publishing. Run the publish through `npx npm@11` so we are
+      # guaranteed to be on a CLI that knows how to do the OIDC
+      # handshake, regardless of PATH/globals.
+      run: npx --yes npm@11 publish --access public
 
   publish-dry-run:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Last attempt globally installed `npm@latest` but the publish step still ran the bundled `npm 10.9.8` from Node 22 and failed with `ENEEDAUTH` (npm 10 doesn't know about OIDC trusted publishing).

Switch to `npx --yes npm@11 publish` so the publish is guaranteed to run on an OIDC-aware CLI, regardless of PATH/globals.