### PR TITLE
Fix OAuth token request being blocked by AWS WAF (HTTP 403)

### DIFF
--- a/__tests__/oauth.test.js
+++ b/__tests__/oauth.test.js
@@ -51,6 +51,28 @@ describe('OAuth client-credentials', () => {
     server.close()
   })
 
+  test('sends the SDK User-Agent on the token request (AWS WAF blocks UA-less requests with 403)', async () => {
+    let tokenHeaders = null
+    const { server, baseURL } = await startServer((req, res) => {
+      if (req.url === '/oauth/token') {
+        tokenHeaders = req.headers
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ access_token: 'tok', expires_in: 3600 }))
+        return
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({}))
+    })
+
+    const client = new BlaaizAPIClient({ client_id: 'id', client_secret: 'secret', baseURL })
+    await client.getOAuthToken()
+
+    expect(tokenHeaders['user-agent']).toBe('Blaaiz-NodeJS-SDK/1.0.0')
+    expect(tokenHeaders.accept).toBe('application/json')
+    expect(tokenHeaders['content-type']).toBe('application/x-www-form-urlencoded')
+    server.close()
+  })
+
   test('caches the token and reuses it across requests', async () => {
     let tokenHits = 0
     const { server, baseURL } = await startServer((req, res) => {

--- a/src/client.js
+++ b/src/client.js
@@ -128,6 +128,7 @@ class BlaaizAPIClient {
         path: url.pathname + url.search,
         method: 'POST',
         headers: {
+          ...this.defaultHeaders,
           'Content-Type': 'application/x-www-form-urlencoded',
           'Content-Length': Buffer.byteLength(body)
         },


### PR DESCRIPTION
## Problem

Businesses migrating from API keys to OAuth get `OAuth token request failed: HTTP 403` on every token request.

The `/oauth/token` request in `_requestToken` built its headers from scratch, and Node's `http` module sends no default User-Agent — so the request went out UA-less. AWS WAF's `AWSManagedRulesCommonRuleSet` (`NoUserAgent_HEADER` rule) blocks it with a bare 403 before it ever reaches the API. Regular API calls were unaffected because `makeRequest` already merges `defaultHeaders`.

Reproduced against `api-dev.blaaiz.com`:
- POST `/oauth/token` **without** a User-Agent → **403** (WAF block, non-JSON body — hence the SDK's generic error message)
- POST `/oauth/token` **with** a User-Agent → **401** `invalid_client` (reaches Passport as expected)

## Fix

Spread `this.defaultHeaders` into the token request options; `Content-Type` still overrides to `application/x-www-form-urlencoded`.

## Tests

- New regression test asserting the token request carries the SDK User-Agent — verified it fails against the previous code and passes with the fix
- Full suite: 130/130 passing, lint clean

Needs a v1.3.1 patch release after merge — a customer is currently blocked on this in dev.