### PR TITLE
Release v1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blaaiz-nodejs-sdk",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blaaiz-nodejs-sdk",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.19.119",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blaaiz-nodejs-sdk",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Official Node.js SDK for Blaaiz RaaS (Remittance as a Service) API",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Patch release: ships #18 — the OAuth token request now sends the SDK default headers (User-Agent, Accept), fixing the AWS WAF 403 (`NoUserAgent_HEADER`) that blocked every OAuth client-credentials token request.

After merge: tag `v1.3.1` and publish the GitHub Release to trigger the npm publish.